### PR TITLE
Fix type sizes in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,8 +504,8 @@ To use the typography that is styled like it is in the Figma UI, use the followi
 
 | Modifier class     | Description                                                                                         |
 |--------------------|-----------------------------------------------------------------------------------------------------|
-| `type--small`      | Font size 11px                                                                                      |
-| `type--large`      | Font size 12px                                                                                      |
+| `type--small`      | Font size 12px                                                                                      |
+| `type--large`      | Font size 13px                                                                                      |
 | `type--xlarge`     | Font size 14px                                                                                      |
 | `type--medium`     | Font weight medium                                                                                  |
 | `type--bold`       | Font weight bold                                                                                    |


### PR DESCRIPTION
Documentation for type modifiers doesn't show the correct sizes. This PR fixes this.

`type--small` is 12px, not 11px
`type--large` is 13px, not 12px