### PR TITLE
Allow nesting disclosures

### DIFF
--- a/dist/figma-plugin-ds.css
+++ b/dist/figma-plugin-ds.css
@@ -887,12 +887,15 @@ body {
   font-weight: var(--font-weight-bold);
 }
 
-.disclosure--expanded .disclosure__content {
+.disclosure--expanded >
+.disclosure__content {
   display: block;
   border-bottom: 1px solid transparent;
+  pointer-events: all;
 }
 
-.disclosure--expanded .disclosure__label:before {
+.disclosure--expanded >
+.disclosure__label:before {
   opacity: 0.8;
   background-image: url("data:image/svg+xml;utf8,%3Csvg%20fill%3D%22none%22%20height%3D%2216%22%20viewBox%3D%220%200%2016%2016%22%20width%3D%2216%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22m9%2010%203-4h-6z%22%20fill%3D%22%23000%22%2F%3E%3C%2Fsvg%3E");
 }
@@ -937,68 +940,55 @@ body {
 }
 
 .icon--blue {
-  -webkit-filter: invert(54%) sepia(16%) saturate(7499%) hue-rotate(179deg) brightness(98%) contrast(101%);
-          filter: invert(54%) sepia(16%) saturate(7499%) hue-rotate(179deg) brightness(98%) contrast(101%);
+  filter: invert(54%) sepia(16%) saturate(7499%) hue-rotate(179deg) brightness(98%) contrast(101%);
 }
 
 .icon--purple {
-  -webkit-filter: invert(40%) sepia(59%) saturate(4001%) hue-rotate(232deg) brightness(103%) contrast(102%);
-          filter: invert(40%) sepia(59%) saturate(4001%) hue-rotate(232deg) brightness(103%) contrast(102%);
+  filter: invert(40%) sepia(59%) saturate(4001%) hue-rotate(232deg) brightness(103%) contrast(102%);
 }
 
 .icon--purple4 {
-  -webkit-filter: invert(72%) sepia(40%) saturate(660%) hue-rotate(202deg) brightness(103%) contrast(103%);
-          filter: invert(72%) sepia(40%) saturate(660%) hue-rotate(202deg) brightness(103%) contrast(103%);
+  filter: invert(72%) sepia(40%) saturate(660%) hue-rotate(202deg) brightness(103%) contrast(103%);
 }
 
 .icon--hot-pink {
-  -webkit-filter: invert(18%) sepia(90%) saturate(3347%) hue-rotate(293deg) brightness(116%) contrast(132%);
-          filter: invert(18%) sepia(90%) saturate(3347%) hue-rotate(293deg) brightness(116%) contrast(132%);
+  filter: invert(18%) sepia(90%) saturate(3347%) hue-rotate(293deg) brightness(116%) contrast(132%);
 }
 
 .icon--green {
-  -webkit-filter: invert(66%) sepia(39%) saturate(5382%) hue-rotate(114deg) brightness(102%) contrast(79%);
-          filter: invert(66%) sepia(39%) saturate(5382%) hue-rotate(114deg) brightness(102%) contrast(79%);
+  filter: invert(66%) sepia(39%) saturate(5382%) hue-rotate(114deg) brightness(102%) contrast(79%);
 }
 
 .icon--red {
-  -webkit-filter: invert(43%) sepia(56%) saturate(5632%) hue-rotate(349deg) brightness(97%) contrast(95%);
-          filter: invert(43%) sepia(56%) saturate(5632%) hue-rotate(349deg) brightness(97%) contrast(95%);
+  filter: invert(43%) sepia(56%) saturate(5632%) hue-rotate(349deg) brightness(97%) contrast(95%);
 }
 
 .icon--yellow {
-  -webkit-filter: invert(78%) sepia(86%) saturate(1608%) hue-rotate(1deg) brightness(107%) contrast(104%);
-          filter: invert(78%) sepia(86%) saturate(1608%) hue-rotate(1deg) brightness(107%) contrast(104%);
+  filter: invert(78%) sepia(86%) saturate(1608%) hue-rotate(1deg) brightness(107%) contrast(104%);
 }
 
 .icon--black {
-  -webkit-filter: invert(0%) sepia(0%) saturate(7500%) hue-rotate(117deg) brightness(109%) contrast(105%);
-          filter: invert(0%) sepia(0%) saturate(7500%) hue-rotate(117deg) brightness(109%) contrast(105%);
+  filter: invert(0%) sepia(0%) saturate(7500%) hue-rotate(117deg) brightness(109%) contrast(105%);
 }
 
 .icon--black8 {
-  -webkit-filter: invert(0%) sepia(56%) saturate(25%) hue-rotate(137deg) brightness(105%) contrast(60%);
-          filter: invert(0%) sepia(56%) saturate(25%) hue-rotate(137deg) brightness(105%) contrast(60%);
+  filter: invert(0%) sepia(56%) saturate(25%) hue-rotate(137deg) brightness(105%) contrast(60%);
 }
 
 .icon--black3 {
-  -webkit-filter: invert(100%) sepia(0%) saturate(698%) hue-rotate(219deg) brightness(66%) contrast(127%);
-          filter: invert(100%) sepia(0%) saturate(698%) hue-rotate(219deg) brightness(66%) contrast(127%);
+  filter: invert(100%) sepia(0%) saturate(698%) hue-rotate(219deg) brightness(66%) contrast(127%);
 }
 
 .icon--white {
-  -webkit-filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(269deg) brightness(103%) contrast(104%);
-          filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(269deg) brightness(103%) contrast(104%);
+  filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(269deg) brightness(103%) contrast(104%);
 }
 
 .icon--white8 {
-  -webkit-filter: invert(99%) sepia(2%) saturate(5%) hue-rotate(55deg) brightness(104%) contrast(98%);
-          filter: invert(99%) sepia(2%) saturate(5%) hue-rotate(55deg) brightness(104%) contrast(98%);
+  filter: invert(99%) sepia(2%) saturate(5%) hue-rotate(55deg) brightness(104%) contrast(98%);
 }
 
 .icon--white4 {
-  -webkit-filter: invert(99%) sepia(2%) saturate(897%) hue-rotate(245deg) brightness(117%) contrast(93%);
-          filter: invert(99%) sepia(2%) saturate(897%) hue-rotate(245deg) brightness(117%) contrast(93%);
+  filter: invert(99%) sepia(2%) saturate(897%) hue-rotate(245deg) brightness(117%) contrast(93%);
 }
 
 .icon--adjust {
@@ -1357,8 +1347,7 @@ body {
 }
 
 .icon-button * {
-  -webkit-filter: invert(0%) sepia(0%) saturate(7500%) hue-rotate(117deg) brightness(109%) contrast(105%);
-          filter: invert(0%) sepia(0%) saturate(7500%) hue-rotate(117deg) brightness(109%) contrast(105%);
+  filter: invert(0%) sepia(0%) saturate(7500%) hue-rotate(117deg) brightness(109%) contrast(105%);
 }
 
 .icon-button:hover {
@@ -1383,8 +1372,7 @@ body {
 }
 
 .icon-button--selected * {
-  -webkit-filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(269deg) brightness(103%) contrast(104%);
-          filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(269deg) brightness(103%) contrast(104%);
+  filter: invert(100%) sepia(100%) saturate(0%) hue-rotate(269deg) brightness(103%) contrast(104%);
 }
 
 .input {
@@ -1411,6 +1399,18 @@ body {
   background-color: var(--white);
 }
 
+.input__field:-moz-placeholder-shown:hover {
+  color: var(--black8);
+  border: 1px solid var(--black1);
+  background-image: none;
+}
+
+.input__field:-ms-input-placeholder:hover {
+  color: var(--black8);
+  border: 1px solid var(--black1);
+  background-image: none;
+}
+
 .input__field:hover, .input__field:placeholder-shown:hover {
   color: var(--black8);
   border: 1px solid var(--black1);
@@ -1427,11 +1427,6 @@ body {
   background-color: var(--blue3);
 }
 
-.input__field::-webkit-input-placeholder {
-  color: var(--black3);
-  border: 1px solid transparent;
-}
-
 .input__field::-moz-placeholder {
   color: var(--black3);
   border: 1px solid transparent;
@@ -1442,18 +1437,33 @@ body {
   border: 1px solid transparent;
 }
 
-.input__field::-ms-input-placeholder {
-  color: var(--black3);
-  border: 1px solid transparent;
-}
-
 .input__field::placeholder {
   color: var(--black3);
   border: 1px solid transparent;
 }
 
+.input__field:-moz-placeholder-shown {
+  border: 1px solid var(--black1);
+}
+
+.input__field:-ms-input-placeholder {
+  border: 1px solid var(--black1);
+}
+
 .input__field:placeholder-shown {
   border: 1px solid var(--black1);
+}
+
+.input__field:focus:-moz-placeholder-shown {
+  border: 1px solid var(--blue);
+  outline: 1px solid var(--blue);
+  outline-offset: -2px;
+}
+
+.input__field:focus:-ms-input-placeholder {
+  border: 1px solid var(--blue);
+  outline: 1px solid var(--blue);
+  outline-offset: -2px;
 }
 
 .input__field:focus:placeholder-shown {
@@ -1925,6 +1935,18 @@ select.select-menu {
   overflow-y: auto;
 }
 
+.textarea:-moz-placeholder-shown:hover {
+  color: var(--black8);
+  border: 1px solid var(--black1);
+  background-image: none;
+}
+
+.textarea:-ms-input-placeholder:hover {
+  color: var(--black8);
+  border: 1px solid var(--black1);
+  background-image: none;
+}
+
 .textarea:hover, .textarea:placeholder-shown:hover {
   color: var(--black8);
   border: 1px solid var(--black1);
@@ -1941,11 +1963,6 @@ select.select-menu {
   background-color: var(--blue3);
 }
 
-.textarea::-webkit-input-placeholder {
-  color: var(--black3);
-  border: 1px solid transparent;
-}
-
 .textarea::-moz-placeholder {
   color: var(--black3);
   border: 1px solid transparent;
@@ -1956,14 +1973,21 @@ select.select-menu {
   border: 1px solid transparent;
 }
 
-.textarea::-ms-input-placeholder {
+.textarea::placeholder {
   color: var(--black3);
   border: 1px solid transparent;
 }
 
-.textarea::placeholder {
-  color: var(--black3);
-  border: 1px solid transparent;
+.textarea:focus:-moz-placeholder-shown {
+  border: 1px solid var(--blue);
+  outline: 1px solid var(--blue);
+  outline-offset: -2px;
+}
+
+.textarea:focus:-ms-input-placeholder {
+  border: 1px solid var(--blue);
+  outline: 1px solid var(--blue);
+  outline-offset: -2px;
 }
 
 .textarea:focus:placeholder-shown {

--- a/src/styles/components/_disclosure.scss
+++ b/src/styles/components/_disclosure.scss
@@ -69,11 +69,13 @@
 		font-weight: var(--font-weight-bold);
     }
     
-    &--expanded & {
+    &--expanded  > 
 		&__content {
 			display: block;
-			border-bottom: 1px solid transparent;
-		}
+            border-bottom: 1px solid transparent;
+            pointer-events: all;
+        }
+    &--expanded >
 		&__label {
 			&:before {
 				opacity: 0.8;
@@ -82,4 +84,3 @@
 		}
 	}
 
-}


### PR DESCRIPTION
Previously expanding a disclosure would make all children content inherit the "expanded" class modifier.
This PR changes the disclosure styling so that only itss child will get the "display: block" expanded modifier.

An example codepen is here: https://codepen.io/lcfinch/pen/qBajYNM