### PR TITLE
align select menu label to the centre

### DIFF
--- a/dist/figma-plugin-ds.css
+++ b/dist/figma-plugin-ds.css
@@ -1669,7 +1669,6 @@ select.select-menu {
   line-height: var(--line-height);
   color: var(--black8);
   margin-right: 6px;
-  margin-top: -2px;
   white-space: nowrap;
   overflow-x: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
it is shifted upwards by margin-top before

before

![image](https://user-images.githubusercontent.com/16908811/145600083-2e3466d4-4d0c-4e13-873c-73dca841b833.png)

after

![image](https://user-images.githubusercontent.com/16908811/145600040-6f179c65-18e2-4a64-850f-06827534df4c.png)
