### PR TITLE
Fix: Typo in Switch Label for "attribute"

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ To use the switch, use the following HTML markup. Remember each switch should ge
 <!-- Switch -->
 <div class="switch">
     <input class="switch__toggle" type="checkbox" id="uniqueId">
-    <label class="switch__label" for="uniqueIdA">Label</label>
+    <label class="switch__label" for="uniqueId">Label</label>
 </div>
 
 <!-- Switch checked -->


### PR DESCRIPTION
The `for=""` attribute of the switch `<label>` does not match the `id=""` of the input above it.

This cause the code snippet to not work properly, when copy-pasting it.