### PR TITLE
Use regular button for select options

### DIFF
--- a/src/js/modules/selectMenu.js
+++ b/src/js/modules/selectMenu.js
@@ -139,6 +139,7 @@ const createWrapper = function(menu) {
 
     //create the button + nested elements
     let button = document.createElement('button')
+    button.type = 'button'
     let icon;
     let buttonLabel = document.createElement('span')
     let buttonCaret = document.createElement('span')


### PR DESCRIPTION
## Issue

If `select` element is wrapped in `form`:

```html
  <form>
      <select class="select-menu">
             <option value="1">Option 1</option>
             <option value="2">Option 2</option>
      </select>
  </form>
```

The form will be submitted every time when user selects a new value. This is undesired behaviour because only explicit submit button must send the form

## Reason

`<button>` html tag has the `type` property set to `submit` by default


## Solution

Set `type` to `button`.

> `button`: The button has no default behavior, and does nothing when pressed by default. It can have client-side scripts listen to the element's events, which are triggered when the events occur.

[MDN](http://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#formenctype)